### PR TITLE
Added "wikiLinks" parameter

### DIFF
--- a/source/DefaultDocumentation/DocumentationGenerator.cs
+++ b/source/DefaultDocumentation/DocumentationGenerator.cs
@@ -17,6 +17,7 @@ namespace DefaultDocumentation
         private readonly XmlDocumentationProvider _documentationProvider;
         private readonly FileNameMode _fileNameMode;
         private readonly NestedTypeVisibility _nestedTypeVisibility;
+        private readonly bool _wikiLinks;
         private readonly Dictionary<string, DocItem> _docItems;
         private readonly Dictionary<string, string> _links;
 
@@ -26,12 +27,14 @@ namespace DefaultDocumentation
             string homePageName,
             FileNameMode fileNameMode,
             NestedTypeVisibility nestedTypeVisibility,
+            bool wikiLinks,
             string linksFiles)
         {
             _decompiler = new CSharpDecompiler(assemblyFilePath, new DecompilerSettings { ThrowOnAssemblyResolveErrors = false });
             _documentationProvider = new XmlDocumentationProvider(documentationFilePath);
             _fileNameMode = fileNameMode;
             _nestedTypeVisibility = nestedTypeVisibility;
+            _wikiLinks = wikiLinks;
 
             _docItems = new Dictionary<string, DocItem>();
             foreach (DocItem item in GetDocItems(homePageName))
@@ -173,7 +176,7 @@ namespace DefaultDocumentation
             {
                 try
                 {
-                    using DocumentationWriter writer = new DocumentationWriter(_fileNameMode, _nestedTypeVisibility, _docItems, _links, outputFolderPath, i);
+                    using DocumentationWriter writer = new DocumentationWriter(_fileNameMode, _nestedTypeVisibility, _wikiLinks, _docItems, _links, outputFolderPath, i);
 
                     i.WriteDocumentation(writer);
                 }
@@ -184,7 +187,7 @@ namespace DefaultDocumentation
             });
         }
 
-        public void WriteLinks(string baseLinkPath, string linksFilePath)
+        public void WriteLinks(string baseLinkPath, string linksFilePath, bool wikiLinks)
         {
             using StreamWriter writer = File.CreateText(linksFilePath);
 
@@ -201,11 +204,11 @@ namespace DefaultDocumentation
                         break;
 
                     case EnumFieldDocItem _:
-                        writer.WriteLine($"{item.Id} {item.Parent.GetLink(_fileNameMode)}.md#{item.GetLink(_fileNameMode)}");
+                        writer.WriteLine($"{item.Id} {item.Parent.GetLink(_fileNameMode)}{(wikiLinks ? "" : ".md")}#{item.GetLink(_fileNameMode)}");
                         break;
 
                     default:
-                        writer.WriteLine($"{item.Id} {item.GetLink(_fileNameMode)}.md");
+                        writer.WriteLine($"{item.Id} {item.GetLink(_fileNameMode)}{(wikiLinks ? "" : ".md")}");
                         break;
                 }
             }

--- a/source/DefaultDocumentation/DocumentationWriter.cs
+++ b/source/DefaultDocumentation/DocumentationWriter.cs
@@ -19,6 +19,7 @@ namespace DefaultDocumentation
 
         private readonly StringBuilder _builder;
         private readonly FileNameMode _fileNameMode;
+        private readonly bool _wikiLinks;
         private readonly IReadOnlyDictionary<string, DocItem> _items;
         private readonly IReadOnlyDictionary<string, string> _links;
         private readonly DocItem _mainItem;
@@ -31,6 +32,7 @@ namespace DefaultDocumentation
         public DocumentationWriter(
             FileNameMode fileNameMode,
             NestedTypeVisibility nestedTypeVisibility,
+            bool wikiLinks,
             IReadOnlyDictionary<string, DocItem> items,
             IReadOnlyDictionary<string, string> links,
             string folderPath,
@@ -42,6 +44,7 @@ namespace DefaultDocumentation
             }
 
             _fileNameMode = fileNameMode;
+            _wikiLinks = wikiLinks;
             NestedTypeVisibility = nestedTypeVisibility;
             _items = items;
             _links = links;
@@ -75,13 +78,13 @@ namespace DefaultDocumentation
         }
 
         public string GetLink(DocItem item, string displayedName = null) =>
-            item.GeneratePage ? $"[{displayedName ?? item.Name}](./{item.GetLink(_fileNameMode)}.md '{item.FullName}')" : GetInnerLink(item, displayedName);
+            item.GeneratePage ? $"[{displayedName ?? item.Name}]({(_wikiLinks ? "" : "./")}{item.GetLink(_fileNameMode)}{(_wikiLinks ? "" : ".md")} '{item.FullName}')" : GetInnerLink(item, displayedName);
 
         public string GetInnerLink(DocItem item, string displayedName = null)
         {
             DocItem pagedDocItem = item.GetPagedDocItem();
 
-            return $"[{displayedName ?? item.Name}]({(_mainItem == pagedDocItem ? string.Empty : $"./{pagedDocItem.GetLink(_fileNameMode)}.md")}#{item.GetLink(_fileNameMode)} '{item.FullName}')";
+            return $"[{displayedName ?? item.Name}]({(_mainItem == pagedDocItem ? string.Empty : $"{(_wikiLinks ? "" : "./")}{pagedDocItem.GetLink(_fileNameMode)}{(_wikiLinks ? "" : ".md")}")}#{item.GetLink(_fileNameMode)} '{item.FullName}')";
         }
 
         public string GetTypeLink(IType type)

--- a/source/DefaultDocumentation/Program.cs
+++ b/source/DefaultDocumentation/Program.cs
@@ -19,6 +19,7 @@ namespace DefaultDocumentation
             string baseLink = null;
             FileInfo linksFile = null;
             string externalLinks = null;
+            bool wikiLinks = false;
 
             try
             {
@@ -63,6 +64,10 @@ namespace DefaultDocumentation
                     else if (TryGetArgValue(arg, nameof(externalLinks), out argValue) && !string.IsNullOrWhiteSpace(argValue))
                     {
                         externalLinks = argValue;
+                    }
+                    else if (TryGetArgValue(arg, nameof(wikiLinks), out argValue) && !string.IsNullOrWhiteSpace(argValue))
+                    {
+                        wikiLinks = bool.Parse(argValue);
                     }
                 }
             }
@@ -127,7 +132,7 @@ namespace DefaultDocumentation
                 StringExtension.ChangeInvalidReplacement(invalidCharReplacement);
             }
 
-            DocumentationGenerator generator = new DocumentationGenerator(assembly.FullName, xml.FullName, home, fileNameMode, nestedTypeVisibility, externalLinks);
+            DocumentationGenerator generator = new DocumentationGenerator(assembly.FullName, xml.FullName, home, fileNameMode, nestedTypeVisibility, wikiLinks, externalLinks);
 
             generator.WriteDocumentation(output.FullName);
 
@@ -138,7 +143,7 @@ namespace DefaultDocumentation
                     linksFile.Delete();
                 }
 
-                generator.WriteLinks(baseLink, linksFile.FullName);
+                generator.WriteLinks(baseLink, linksFile.FullName, wikiLinks);
             }
 
             static bool TryGetArgValue(string arg, string argName, out string value)
@@ -166,6 +171,7 @@ namespace DefaultDocumentation
                 Console.WriteLine($"\t/{nameof(baseLink)}:{{base link path used if generating a links file}}");
                 Console.WriteLine($"\t/{nameof(linksFile)}:{{links file path}}");
                 Console.WriteLine($"\t/{nameof(externalLinks)}:{{links files for element outside of this assembly, separated by '|'}}");
+                Console.WriteLine($"\t/{nameof(wikiLinks)}:{{uses github wiki link format (no relativity or file type suffix}}");
             }
         }
     }

--- a/source/DefaultDocumentation/build/DefaultDocumentation.targets
+++ b/source/DefaultDocumentation/build/DefaultDocumentation.targets
@@ -11,9 +11,10 @@
       <DefaultDocumentationFileNameMode Condition="'$(DefaultDocumentationFileNameMode)' == ''">FullName</DefaultDocumentationFileNameMode>
       <DefaultDocumentationNestedTypeVisibility Condition="'$(DefaultDocumentationNestedTypeVisibility)' == ''">Namespace</DefaultDocumentationNestedTypeVisibility>
       <DefaultDocumentationLinksFile Condition="'$(DefaultDocumentationLinksFile)' != ''">$([System.IO.Path]::GetFullPath($(DefaultDocumentationLinksFile)))</DefaultDocumentationLinksFile>
+      <DefaultDocumentationWikiLinks Condition="'$(DefaultDocumentationWikiLinks)' == ''">false</DefaultDocumentationWikiLinks>
 
       <DefaultDocumentationArgs>/assembly:"$(TargetPath)" /xml:"$(DocumentationFile)"</DefaultDocumentationArgs>
-      <DefaultDocumentationOptionalArgs>/output:"$(DefaultDocumentationFolder)" /home:"$(DefaultDocumentationHome)" /fileNameMode:"$(DefaultDocumentationFileNameMode)" /nestedTypeVisibility:"$(DefaultDocumentationNestedTypeVisibility)" /invalidCharReplacement:"$(DefaultDocumentationInvalidCharReplacement)"</DefaultDocumentationOptionalArgs>
+      <DefaultDocumentationOptionalArgs>/output:"$(DefaultDocumentationFolder)" /home:"$(DefaultDocumentationHome)" /fileNameMode:"$(DefaultDocumentationFileNameMode)" /nestedTypeVisibility:"$(DefaultDocumentationNestedTypeVisibility)" /invalidCharReplacement:"$(DefaultDocumentationInvalidCharReplacement)" /wikiLinks:"$(DefaultDocumentationWikiLinks)"</DefaultDocumentationOptionalArgs>
     </PropertyGroup>
     <Exec Command="$(DefaultDocumentationTool) $(DefaultDocumentationArgs) $(DefaultDocumentationOptionalArgs)"/>
   </Target>


### PR DESCRIPTION
Firstly, thanks for your work on this repo - it's really useful.
Was hoping you'd be able to consider this pull request, when convenient.  The intent is to make the resulting markdown compatible with deployment to a GitHub Wiki.

In their default format, the path prefix and .md extensions on the generated links prevent them from being navigated if deployed to a Wiki.  Used in conjunction with the FullName FileNameMode parameter, it is possible to produce a functional Wiki with the link formats simplified.  I appreciate that this may not necessarily be in scope of the intent for the repo but, if you'd be prepared to accommodate it, there shouldn't be any negative impact and it defaults to disabled, naturally.

I've generated an example Wiki on my forked repo, using the Dummy project.  You can review it here:
https://github.com/welshronaldo/DefaultDocumentation/wiki

Thanks in advance for your time!