### PR TITLE
Add multi-target support

### DIFF
--- a/source/DefaultDocumentation.sln
+++ b/source/DefaultDocumentation.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		..\.gitignore = ..\.gitignore
+		global.json = global.json
 		..\LICENSE.md = ..\LICENSE.md
 		..\documentation\NEXT_RELEASENOTES.txt = ..\documentation\NEXT_RELEASENOTES.txt
 		..\README.md = ..\README.md

--- a/source/DefaultDocumentation/DefaultDocumentation.csproj
+++ b/source/DefaultDocumentation/DefaultDocumentation.csproj
@@ -1,65 +1,84 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Label="Compilation">
-    <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
-    <TargetFrameworks>
-      net472;
-      netcoreapp3.1;
-    </TargetFrameworks>
-    <Optimize>true</Optimize>
-  </PropertyGroup>
+	<PropertyGroup Label="Compilation">
+		<OutputType>Exe</OutputType>
+		<LangVersion>latest</LangVersion>
+		<TargetFrameworks>
+			net5.0;
+			netcoreapp3.1;
+			netcoreapp3.0;
+			netcoreapp2.2;
+			netcoreapp2.1;
+			netcoreapp2.0;
+			net472;
+		</TargetFrameworks>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <PropertyGroup Label="Debug" Condition="'$(Configuration)'=='Debug'">
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Label="Debug" Condition="'$(Configuration)'=='Debug'">
+		<Optimize>false</Optimize>
+		<DefineConstants>DEBUG</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="DefaultDocumentation.targets" />
-    <None Include="bin\Release\net472\*.dll" Pack="true" PackagePath="tools\" Visible="false" />
-    <Content Include="..\..\image\logo.png" PackagePath="\" Visible="false"/>
-    <Content Include="build\DefaultDocumentation.targets" PackagePath="build\" />
-  </ItemGroup>
+	<!--Include target framework output tool-->
+	<PropertyGroup>
+		<IsTool>false</IsTool>
+		<DevelopmentDependency>true</DevelopmentDependency>
+		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);ToolDependenciesTarget</TargetsForTfmSpecificBuildOutput>
+	</PropertyGroup>
+	<Target Name="ToolDependenciesTarget">
+		<Message Text="Including dependencies from $(OutputPath)" Importance="high" />
+		<ItemGroup>
+			<TfmSpecificPackageFile
+				Include="$(OutputPath)\**"
+				Exclude="$(OutputPath)\$(TargetName).exe;$(OutputPath)\$(TargetName).pdb">
+				<PackagePath>tools\$(TargetFramework)</PackagePath>
+			</TfmSpecificPackageFile>
+		</ItemGroup>
+	</Target>
 
-  <ItemGroup Label="Reference">
-    <PackageReference Include="ICSharpCode.Decompiler" Version="6.2.1.6137" />
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="..\..\image\logo.png" PackagePath="\" Visible="false" />
+		<Content Include="build\DefaultDocumentation.targets" PackagePath="build\" />
+		<None Remove="DefaultDocumentation.targets" />
+	</ItemGroup>
 
-  <PropertyGroup Label="Package">
-    <Authors>Paillat Laszlo</Authors>
-    <AssemblyName>DefaultDocumentation</AssemblyName>
-    <AssemblyTitle>DefaultDocumentation</AssemblyTitle>
-    <PackageId>DefaultDocumentation</PackageId>
-    <Description>Create a simple markdown documentation from the Visual Studio xml one.</Description>
-    <PackageIcon>logo.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Doraku/DefaultDocumentation</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/Doraku/DefaultDocumentation.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>markdown documentation</PackageTags>
+	<ItemGroup Label="Reference">
+		<PackageReference Include="ICSharpCode.Decompiler" Version="6.2.1.6137" />
+	</ItemGroup>
 
-    <IsTool>true</IsTool>
-    <DevelopmentDependency>true</DevelopmentDependency>
-  </PropertyGroup>
+	<PropertyGroup Label="Package">
+		<Authors>Paillat Laszlo</Authors>
+		<AssemblyName>DefaultDocumentation</AssemblyName>
+		<AssemblyTitle>DefaultDocumentation</AssemblyTitle>
+		<PackageId>DefaultDocumentation</PackageId>
+		<Description>Create a simple markdown documentation from the Visual Studio xml one.</Description>
+		<PackageIcon>logo.png</PackageIcon>
+		<PackageProjectUrl>https://github.com/Doraku/DefaultDocumentation</PackageProjectUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<RepositoryUrl>https://github.com/Doraku/DefaultDocumentation.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>markdown documentation</PackageTags>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(LOCAL_VERSION)' == 'true'">
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\ds.snk</AssemblyOriginatorKeyFile>
-    <Version>0-local$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(LOCAL_VERSION)' == 'true'">
+		<SignAssembly>True</SignAssembly>
+		<AssemblyOriginatorKeyFile>..\..\..\ds.snk</AssemblyOriginatorKeyFile>
+		<Version>0-local$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' AND '$(TEST)' != 'true'">
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\ds.snk</AssemblyOriginatorKeyFile>
-    <Version Condition="'$(CI_VERSION)' == 'true'">0-ci$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' AND '$(TEST)' != 'true'">
+		<SignAssembly>True</SignAssembly>
+		<AssemblyOriginatorKeyFile>..\..\ds.snk</AssemblyOriginatorKeyFile>
+		<Version Condition="'$(CI_VERSION)' == 'true'">0-ci$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
+	</PropertyGroup>
 
-  <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
-    <ReadLinesFromFile File="../../documentation/NEXT_RELEASENOTES.txt">
-      <Output TaskParameter="Lines" ItemName="ReleaseNotesLines" />
-    </ReadLinesFromFile>
-    <PropertyGroup>
-      <PackageReleaseNotes>@(ReleaseNotesLines, '%0a')</PackageReleaseNotes>
-    </PropertyGroup>
-  </Target>
+	<Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
+		<ReadLinesFromFile File="../../documentation/NEXT_RELEASENOTES.txt">
+			<Output TaskParameter="Lines" ItemName="ReleaseNotesLines" />
+		</ReadLinesFromFile>
+		<PropertyGroup>
+			<PackageReleaseNotes>@(ReleaseNotesLines, '%0a')</PackageReleaseNotes>
+		</PropertyGroup>
+	</Target>
+
 </Project>

--- a/source/DefaultDocumentation/build/DefaultDocumentation.targets
+++ b/source/DefaultDocumentation/build/DefaultDocumentation.targets
@@ -1,21 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="DefaultDocumentation" AfterTargets="PostBuildEvent" Condition="'$(GenerateDocumentationFile)' == 'true' AND '$(DisableDefaultDocumentation)' != 'true'">
-    <PropertyGroup>
-      <DefaultDocumentationTool>dotnet "$(MSBuildThisFileDirectory)../tools/DefaultDocumentation.dll"</DefaultDocumentationTool>
-      <DefaultDocumentationTool Condition="$([MSBuild]::IsOsPlatform('Windows'))">"$(MSBuildThisFileDirectory)../tools/DefaultDocumentation.exe"</DefaultDocumentationTool>
+	<Target Name="DefaultDocumentation" AfterTargets="PostBuildEvent" Condition="'$(GenerateDocumentationFile)' == 'true' AND '$(DisableDefaultDocumentation)' != 'true'">
+		<PropertyGroup>
+			<DefaultDocumentationFallbackToolTargetFramework>net5.0</DefaultDocumentationFallbackToolTargetFramework>
+			<DefaultDocumentationFallbackTool>$(MSBuildThisFileDirectory)../tools/$(DefaultDocumentationFallbackToolTargetFramework)/DefaultDocumentation.dll</DefaultDocumentationFallbackTool>
+			<DefaultDocumentationTool>$(MSBuildThisFileDirectory)../tools/$(TargetFramework)/DefaultDocumentation.dll</DefaultDocumentationTool>
 
-      <DocumentationFile Condition="'$(DocumentationFile)' != ''">$([System.IO.Path]::GetFullPath($(DocumentationFile)))</DocumentationFile>
+			<DocumentationFile Condition="'$(DocumentationFile)' != ''">$([System.IO.Path]::GetFullPath($(DocumentationFile)))</DocumentationFile>
 
-      <DefaultDocumentationFolder Condition="'$(DefaultDocumentationFolder)' != ''">$([System.IO.Path]::GetFullPath($(DefaultDocumentationFolder)))</DefaultDocumentationFolder>
-      <DefaultDocumentationFileNameMode Condition="'$(DefaultDocumentationFileNameMode)' == ''">FullName</DefaultDocumentationFileNameMode>
-      <DefaultDocumentationNestedTypeVisibility Condition="'$(DefaultDocumentationNestedTypeVisibility)' == ''">Namespace</DefaultDocumentationNestedTypeVisibility>
-      <DefaultDocumentationLinksFile Condition="'$(DefaultDocumentationLinksFile)' != ''">$([System.IO.Path]::GetFullPath($(DefaultDocumentationLinksFile)))</DefaultDocumentationLinksFile>
-      <DefaultDocumentationWikiLinks Condition="'$(DefaultDocumentationWikiLinks)' == ''">false</DefaultDocumentationWikiLinks>
+			<DefaultDocumentationFolder Condition="'$(DefaultDocumentationFolder)' != ''">$([System.IO.Path]::GetFullPath($(DefaultDocumentationFolder)))</DefaultDocumentationFolder>
+			<DefaultDocumentationFileNameMode Condition="'$(DefaultDocumentationFileNameMode)' == ''">FullName</DefaultDocumentationFileNameMode>
+			<DefaultDocumentationNestedTypeVisibility Condition="'$(DefaultDocumentationNestedTypeVisibility)' == ''">Namespace</DefaultDocumentationNestedTypeVisibility>
+			<DefaultDocumentationLinksFile Condition="'$(DefaultDocumentationLinksFile)' != ''">$([System.IO.Path]::GetFullPath($(DefaultDocumentationLinksFile)))</DefaultDocumentationLinksFile>
+			<DefaultDocumentationWikiLinks Condition="'$(DefaultDocumentationWikiLinks)' == ''">false</DefaultDocumentationWikiLinks>
 
-      <DefaultDocumentationArgs>/assembly:"$(TargetPath)" /xml:"$(DocumentationFile)"</DefaultDocumentationArgs>
-      <DefaultDocumentationOptionalArgs>/output:"$(DefaultDocumentationFolder)" /home:"$(DefaultDocumentationHome)" /fileNameMode:"$(DefaultDocumentationFileNameMode)" /nestedTypeVisibility:"$(DefaultDocumentationNestedTypeVisibility)" /invalidCharReplacement:"$(DefaultDocumentationInvalidCharReplacement)" /wikiLinks:"$(DefaultDocumentationWikiLinks)"</DefaultDocumentationOptionalArgs>
-    </PropertyGroup>
-    <Exec Command="$(DefaultDocumentationTool) $(DefaultDocumentationArgs) $(DefaultDocumentationOptionalArgs)"/>
-  </Target>
+			<DefaultDocumentationArgs>/assembly:"$(TargetPath)" /xml:"$(DocumentationFile)"</DefaultDocumentationArgs>
+			<DefaultDocumentationOptionalArgs>/output:"$(DefaultDocumentationFolder)" /home:"$(DefaultDocumentationHome)" /fileNameMode:"$(DefaultDocumentationFileNameMode)" /nestedTypeVisibility:"$(DefaultDocumentationNestedTypeVisibility)" /invalidCharReplacement:"$(DefaultDocumentationInvalidCharReplacement)" /wikiLinks:"$(DefaultDocumentationWikiLinks)"</DefaultDocumentationOptionalArgs>
+		</PropertyGroup>
+
+		<Warning Condition="!Exists('$(DefaultDocumentationTool)')"
+			Text="Target framework `$(TargetFramework)` is not supported by DefaultDocumentation. Fallbacking to `$(DefaultDocumentationFallbackToolTargetFramework)`." />
+		<Exec Condition="Exists('$(DefaultDocumentationTool)')"
+			Command="dotnet &quot;$(DefaultDocumentationTool)&quot; $(DefaultDocumentationArgs) $(DefaultDocumentationOptionalArgs)"/>
+	
+		<Error Condition="!Exists('$(DefaultDocumentationFallbackTool)')"
+			Text="Fallback default documentation tool `$(DefaultDocumentationFallbackTool)` doesn't exist. You can configure default fallback target framework by specifying `DefaultDocumentationFallbackToolTargetFramework` property." />
+		<Exec Condition="Exists('$(DefaultDocumentationFallbackTool)')"
+				Command="dotnet &quot;$(DefaultDocumentationFallbackTool)&quot; $(DefaultDocumentationArgs) $(DefaultDocumentationOptionalArgs)"/>
+
+	</Target>
 </Project>

--- a/source/global.json
+++ b/source/global.json
@@ -1,0 +1,10 @@
+﻿{
+	"projects": [
+		"src",
+		"test"
+	],
+	"sdk": {
+		"rollForward": "latestPatch",
+		"version": "5.0.100"
+	}
+}


### PR DESCRIPTION
Hello,

This PR adds support for more target frameworks not only (framework4.7.2 or netcoreapp3.0):
 * net5.0;
 * netcoreapp3.1;
 * netcoreapp2.2;
 * netcoreapp2.1;
 * netcoreapp2.0;
 * netstandardX.X (by adding property called `DefaultDocumentationFallbackToolTargetFramework`);

For libraries that target `netstandard` the tool fallbacks to the specified fallback target framework (by default is set to .net5.0);

One possible improvement could be made inorder to support multiple target frameworks by default is to set the default `DefaultDocumentationFolder` in `build/DefaultDocumentation.targets` to include `$(TargetFramework)`.
That way when for example my library X targets `netstandard2.0` and `net5.0` multiple documentation versions will be generated in different directories. (but this is not required because user can specify it manually)

I have local build for my needs, but i will love to seе these changes in the official package.
