### PR TITLE
Fix code examples from external files

### DIFF
--- a/source/DefaultDocumentation/DefaultDocumentation.targets
+++ b/source/DefaultDocumentation/DefaultDocumentation.targets
@@ -38,7 +38,7 @@
     <DefaultDocumentationTask
       AssemblyFilePath="$(TargetPath)"
       DocumentationFilePath="$(_DefaultDocumentationDocumentationFile)"
-      ProjectDirectoryPath="$(ProjectPath)"
+      ProjectDirectoryPath="$(ProjectDir)"
       OutputDirectoryPath="$(_DefaultDocumentationFolder)"
       InvalidCharReplacement="$(DefaultDocumentationInvalidCharReplacement)"
       AssemblyPageName="$(DefaultDocumentationAssemblyPageName)"


### PR DESCRIPTION
The functionality to get code examples from actual code files seems to be broken after the big refactoring.