### PR TITLE
Filtered out compiler generated types that are currently being included with "IncludeUndocumentedItems"

### DIFF
--- a/source/DefaultDocumentation.Common/DocItemReader.cs
+++ b/source/DefaultDocumentation.Common/DocItemReader.cs
@@ -62,9 +62,15 @@ namespace DefaultDocumentation
             {
                 _logger.Debug($"handling type \"{type.FullName}\"");
 
-                if (type.IsCompilerGenerated())
+                if (type.IsCompilerGenerated() || type.IsCompilerGeneratedOrIsInCompilerGeneratedClass())
                 {
                     _logger.Debug($"Skipping documentation for type \"{type.FullName}\": compiler generated");
+                    continue;
+                }
+
+                if (String.IsNullOrWhiteSpace(type.Namespace))
+                {
+                    _logger.Debug($"Skipping documentation for type \"{type.FullName}\": empty namespace");
                     continue;
                 }
 
@@ -135,6 +141,7 @@ namespace DefaultDocumentation
                         _logger.Debug($"handling member \"{entity.FullName}\"");
 
                         if (entity.IsCompilerGenerated()
+                            || entity.IsCompilerGeneratedOrIsInCompilerGeneratedClass()
                             || (entity is IField && typeDocItem is EnumDocItem && entity.Name == "value__"))
                         {
                             _logger.Debug($"Skipping documentation for member \"{entity.FullName}\": compiler generated");

--- a/source/DefaultDocumentation.Common/DocItemReader.cs
+++ b/source/DefaultDocumentation.Common/DocItemReader.cs
@@ -62,7 +62,7 @@ namespace DefaultDocumentation
             {
                 _logger.Debug($"handling type \"{type.FullName}\"");
 
-                if (type.IsCompilerGenerated() || type.IsCompilerGeneratedOrIsInCompilerGeneratedClass())
+                if (type.IsCompilerGenerated())
                 {
                     _logger.Debug($"Skipping documentation for type \"{type.FullName}\": compiler generated");
                     continue;
@@ -105,6 +105,13 @@ namespace DefaultDocumentation
                     {
                         declaringTypeDocItem = GetDocItem(currentType, parentDocItem);
 
+                        if (currentType.IsCompilerGenerated())
+                        {
+                            _logger.Debug($"Skipping documentation for type \"{type.FullName}\": declaring type \"{declaringTypeDocItem.FullName}\" is compiler generated");
+                            parentDocItem = null;
+                            break;
+                        }
+
                         if (declaringTypeDocItem.Documentation?.HasExclude() is true)
                         {
                             _logger.Debug($"Skipping documentation for type \"{type.FullName}\": exclude tag found in declaring type \"{declaringTypeDocItem.FullName}\" documentation");
@@ -141,7 +148,6 @@ namespace DefaultDocumentation
                         _logger.Debug($"handling member \"{entity.FullName}\"");
 
                         if (entity.IsCompilerGenerated()
-                            || entity.IsCompilerGeneratedOrIsInCompilerGeneratedClass()
                             || (entity is IField && typeDocItem is EnumDocItem && entity.Name == "value__"))
                         {
                             _logger.Debug($"Skipping documentation for member \"{entity.FullName}\": compiler generated");


### PR DESCRIPTION
I have identified two issues with the current implementation of  the `IncudeUndocumentedItems` option.

### 1. The current output includes compiler generated "DisplayClass" types that should not be present.. see below:

```markdown
#### [TerminalUI](index.md 'index')
## FoxHollow.TerminalUI Namespace

| Classes | |
| :--- | :--- |
| [Helpers](FoxHollow_TerminalUI_Helpers.md 'FoxHollow.TerminalUI.Helpers') | Static class containing miscellaneous helper methods  |
| [Helpers.&lt;&gt;c__DisplayClass0_0](FoxHollow_TerminalUI_Helpers___c__DisplayClass0_0.md 'FoxHollow.TerminalUI.Helpers.&lt;&gt;c__DisplayClass0_0') |  |
| [Helpers.&lt;&gt;c__DisplayClass0_0.&lt;&lt;SetupTaskWatchdog&gt;b__0&gt;d](FoxHollow_TerminalUI_Helpers___c__DisplayClass0_0___SetupTaskWatchdog_b__0_d.md 'FoxHollow.TerminalUI.Helpers.&lt;&gt;c__DisplayClass0_0.&lt;&lt;SetupTaskWatchdog&gt;b__0&gt;d') |  |
| [KeyInput](FoxHollow_TerminalUI_KeyInput.md 'FoxHollow.TerminalUI.KeyInput') | Class used for reading key input from the terminal  |
| [Terminal](FoxHollow_TerminalUI_Terminal.md 'FoxHollow.TerminalUI.Terminal') | Static helper class for simplifying a console-based, interactive user interface  |
| [Terminal.&lt;&gt;c__DisplayClass72_0](FoxHollow_TerminalUI_Terminal___c__DisplayClass72_0.md 'FoxHollow.TerminalUI.Terminal.&lt;&gt;c__DisplayClass72_0') |  |
| [Terminal.&lt;&gt;c__DisplayClass72_0.&lt;&lt;Run&gt;b__0&gt;d](FoxHollow_TerminalUI_Terminal___c__DisplayClass72_0___Run_b__0_d.md 'FoxHollow.TerminalUI.Terminal.&lt;&gt;c__DisplayClass72_0.&lt;&lt;Run&gt;b__0&gt;d') |  |
| [TerminalColor](FoxHollow_TerminalUI_TerminalColor.md 'FoxHollow.TerminalUI.TerminalColor') | Allow to specify the default colors for the terminal  |
| [TerminalPoint](FoxHollow_TerminalUI_TerminalPoint.md 'FoxHollow.TerminalUI.TerminalPoint') | Class used to make interacting with terminal positioning much easier  |
| [TerminalPointMove](FoxHollow_TerminalUI_TerminalPointMove.md 'FoxHollow.TerminalUI.TerminalPointMove') | TerminalPoint helper class that allows to wrap a TerminalPoint move action into a using() { } block so that, upon exiting the  block, the cursor is automatically returned to the previous location  |
```

I was able to filter these out by adding a check in `DocItemReader` using `type.IsCompilerGeneratedOrIsInCompilerGeneratedClass()`. I compared the output with and without this check in place, and the only difference that is now being excluded is the invalid classes.

See below for output AFTER this check was put in place:

```markdown
#### [TerminalUI](index.md 'index')
## FoxHollow.TerminalUI Namespace

| Classes | |
| :--- | :--- |
| [Helpers](FoxHollow_TerminalUI_Helpers.md 'FoxHollow.TerminalUI.Helpers') | Static class containing miscellaneous helper methods<br/> |
| [KeyInput](FoxHollow_TerminalUI_KeyInput.md 'FoxHollow.TerminalUI.KeyInput') | Class used for reading key input from the terminal<br/> |
| [Terminal](FoxHollow_TerminalUI_Terminal.md 'FoxHollow.TerminalUI.Terminal') | Static helper class for simplifying a console-based, interactive user interface<br/> |
| [TerminalColor](FoxHollow_TerminalUI_TerminalColor.md 'FoxHollow.TerminalUI.TerminalColor') | Allow to specify the default colors for the terminal<br/> |
| [TerminalPoint](FoxHollow_TerminalUI_TerminalPoint.md 'FoxHollow.TerminalUI.TerminalPoint') | Class used to make interacting with terminal positioning much easier<br/> |
| [TerminalPointMove](FoxHollow_TerminalUI_TerminalPointMove.md 'FoxHollow.TerminalUI.TerminalPointMove') | TerminalPoint helper class that allows to wrap a TerminalPoint<br/>move action into a using() { } block so that, upon exiting the <br/>block, the cursor is automatically returned to the previous location<br/> |
```


### 2. The output generates a `.md` file and a `_Module.md` file, and an empty row in the `index.md` file. See below:

![image](https://user-images.githubusercontent.com/3877800/135459739-6d602c08-8555-485e-aa63-bd8442364c11.png)

I have attached `.md` and `_Module.md` in case you would like to review what is being generated

[.md](https://github.com/Doraku/DefaultDocumentation/files/7259674/default.md)
[_Module_.md](https://github.com/Doraku/DefaultDocumentation/files/7259677/_Module_.md)

Additionally.., this is what the `index.md` file looks:

```markdown
#### [TerminalUI](index.md 'index')

| Namespaces | |
| :--- | :--- |
| [](.md '') |  |
| [FoxHollow.TerminalUI](FoxHollow_TerminalUI.md 'FoxHollow.TerminalUI') |  |
| [FoxHollow.TerminalUI.Elements](FoxHollow_TerminalUI_Elements.md 'FoxHollow.TerminalUI.Elements') |  |
| [FoxHollow.TerminalUI.Types](FoxHollow_TerminalUI_Types.md 'FoxHollow.TerminalUI.Types') |  |
```

I was able to filter out this invalid namespace and type entry by looking for a type with no namespace defined in `DocItemReader`: 

```csharp
if (String.IsNullOrWhiteSpace(type.Namespace))
{
    _logger.Debug($"Skipping documentation for type \"{type.FullName}\": empty namespace");
    continue;
}
```

This pull request resolves both of these issues