### PR TITLE
Add `ItemListFile` parameter

### DIFF
--- a/source/DefaultDocumentation.Common/Settings.cs
+++ b/source/DefaultDocumentation.Common/Settings.cs
@@ -50,6 +50,12 @@ namespace DefaultDocumentation
 
         public string LinksBaseUrl { get; }
 
+        /// <summary>
+        /// The file where the item list will be written.
+        /// </summary>
+        /// <value>Item/member list file?</value>
+        public FileInfo ItemListFile { get; }
+
         public FileInfo[] ExternLinksFiles { get; }
 
         public Settings(
@@ -70,6 +76,7 @@ namespace DefaultDocumentation
             bool ignoreLineBreak,
             string linksOutputFile,
             string linksBaseUrl,
+            string itemListFile,
             IEnumerable<string> externlinksFilePaths)
         {
             LoggingConfiguration logConfiguration = new();
@@ -126,6 +133,9 @@ namespace DefaultDocumentation
 
             LinksBaseUrl = linksBaseUrl ?? string.Empty;
             Logger.Info($"{nameof(LinksBaseUrl)}: {LinksBaseUrl}");
+
+            ItemListFile = string.IsNullOrEmpty(itemListFile) ? null : new FileInfo(itemListFile);
+            Logger.Info($"{nameof(ItemListFile)}: {ItemListFile.FullName}");
 
             ExternLinksFiles = (externlinksFilePaths ?? Enumerable.Empty<string>()).SelectMany(GetFilePaths).Distinct().Select(f => new FileInfo(f)).Where(f => f.Exists && f.FullName != LinksOutputFile?.FullName).ToArray();
             Logger.Info($"{nameof(ExternLinksFiles)}:{string.Concat(ExternLinksFiles.Select(f => $"{Environment.NewLine}\t{f.FullName}"))}");

--- a/source/DefaultDocumentation.Console/Program.cs
+++ b/source/DefaultDocumentation.Console/Program.cs
@@ -48,6 +48,7 @@ namespace DefaultDocumentation
                         a.IgnoreLineBreak,
                         a.LinksOutputFilePath,
                         a.LinksBaseUrl,
+                        a.ItemListFile,
                         a.ExternLinksFilePaths));
                 });
         }

--- a/source/DefaultDocumentation.Console/SettingsArgs.cs
+++ b/source/DefaultDocumentation.Console/SettingsArgs.cs
@@ -53,6 +53,9 @@ namespace DefaultDocumentation
         [Option('b', nameof(LinksBaseUrl), Required = false, HelpText = "Base url of the documentation for the generated links file")]
         public string LinksBaseUrl { get; set; }
 
+        [Option('f', nameof(ItemListFile), Required = false, HelpText = "Path of the file where all included items will be added")]
+        public string ItemListFile { get; set; }
+
         [Option('e', nameof(ExternLinksFilePaths), Required = false, Separator = '|', HelpText = "Links files to use for external documentation")]
         public IEnumerable<string> ExternLinksFilePaths { get; set; }
     }

--- a/source/DefaultDocumentation/DefaultDocumentationTask.cs
+++ b/source/DefaultDocumentation/DefaultDocumentationTask.cs
@@ -38,6 +38,12 @@ namespace DefaultDocumentation
 
         public string LinksBaseUrl { get; set; }
 
+        /// <summary>
+        /// The file where the item list will be written.
+        /// </summary>
+        /// <value>Item/member list file?</value>
+        public string ItemListFile { get; set; }
+
         public string ExternLinksFilePaths { get; set; }
 
         public override bool Execute()
@@ -65,6 +71,7 @@ namespace DefaultDocumentation
                 IgnoreLineBreak,
                 LinksOutputFilePath,
                 LinksBaseUrl,
+                ItemListFile,
                 (ExternLinksFilePaths ?? string.Empty).Split('|')));
 
             return true;


### PR DESCRIPTION
Made a mistake in the commit name, but yeah.

This basically adds `-f`/`--ItemListFile` flag and also `<DefaultDocumentationItemListFile>` tag that allow setting where item list will be written. It will be written as such:
```md
- [Assembly](assembly.md 'Assembly')
  - [Type](type.md 'Assembly.Type')
```
Only items that have their own pages will be written.

Not sure if comments are minded here, but I added them regardless.

Only command line variant was tested.