### PR TITLE
Add `<term>` support for lists and tables

### DIFF
--- a/source/DefaultDocumentation.Common/Helper/XElementExtension.cs
+++ b/source/DefaultDocumentation.Common/Helper/XElementExtension.cs
@@ -18,8 +18,6 @@ namespace DefaultDocumentation.Helper
 
         public static IEnumerable<XElement> GetItems(this XElement element) => element?.Descendants("item") ?? Enumerable.Empty<XElement>();
 
-        public static IEnumerable<XElement> GetDescriptions(this XElement element) => element?.Descendants("description") ?? Enumerable.Empty<XElement>();
-
         public static XElement GetReturns(this XElement element) => element?.Element("returns");
 
         public static XElement GetRemarks(this XElement element) => element?.Element("remarks");
@@ -29,6 +27,10 @@ namespace DefaultDocumentation.Helper
         public static XElement GetValue(this XElement element) => element?.Element("value");
 
         public static XElement GetListHeader(this XElement element) => element?.Element("listheader");
+
+        public static XElement GetDescription(this XElement element) => element?.Element("description");
+
+        public static XElement GetTerm(this XElement element) => element?.Element("term");
 
         public static string GetNameAttribute(this XElement element) => element.Attribute("name")?.Value;
 

--- a/source/Dummy/DummyClass.cs
+++ b/source/Dummy/DummyClass.cs
@@ -44,6 +44,45 @@ namespace Dummy
     /// <description>pouet</description>
     /// </item>
     /// </list>
+    /// <list type="bullet">
+    /// <item>
+    /// <term>
+    /// <see cref="DummyEnum"/>
+    /// </term>
+    /// <description>Description</description>
+    /// </item>
+    /// <item>
+    /// <term>Term</term>
+    /// <description>
+    /// <para>Para 1</para>
+    /// <para>Para 2</para>
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <term>
+    /// <para>Para 1</para>
+    /// <para>Para 2</para>
+    /// </term>
+    /// <description>
+    /// <para>Para 3</para>
+    /// <para>Para 4</para>
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Number</term>
+    /// <description>Description</description>
+    /// </listheader>
+    /// <item>
+    /// <term>0</term>
+    /// <description>Description</description>
+    /// </item>
+    /// <item>
+    /// <term>1</term>
+    /// <description>Description</description>
+    /// </item>
+    /// </list>
     /// </summary>
     public class DummyClass
     {


### PR DESCRIPTION
Adds support for `<term>` tag.

Tables treat `<term>` the same as `<description>`, while number and bullet lists add `—` after the term.