### PR TITLE
Switch to base36 instead of base64 for MD5 hashes to avoid using special characters

### DIFF
--- a/source/DefaultDocumentation.Markdown/FileNameFactories/Md5Factory.cs
+++ b/source/DefaultDocumentation.Markdown/FileNameFactories/Md5Factory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 using System.Security.Cryptography;
 using System.Text;
 using DefaultDocumentation.Models;
@@ -23,7 +24,42 @@ namespace DefaultDocumentation.Markdown.FileNameFactories
         {
             using MD5 md5 = MD5.Create();
 
-            return Convert.ToBase64String(md5.ComputeHash(Encoding.UTF8.GetBytes(item.FullName))).Replace('\\', '?').Replace('/', '?');
+            return GetMd5HashBase36(item.FullName);
+        }
+
+        internal static string GetMd5HashBase36(string text)
+        {
+            using MD5 md5 = MD5.Create();
+            return ToBase36String(md5.ComputeHash(Encoding.UTF8.GetBytes(text)));
+        }
+
+        private static string ToBase36String(byte[] bytes)
+        {
+            // The base 36 alphabet results in concise hashes which are case-insensitive and contain
+            // no special characters, ensuring compatibility in a wide range of scenarios
+            const string Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+            BigInteger bigInteger = ToNonNegativeBigInteger(bytes);
+            StringBuilder result = new();
+            while (!bigInteger.IsZero)
+            {
+                bigInteger = BigInteger.DivRem(bigInteger, Alphabet.Length, out BigInteger remainder);
+                result.Append(Alphabet[(int)remainder]);
+            }
+
+            if (result.Length == 0)
+            {
+                result.Append(Alphabet[0]); // ensure the result is never empty
+            }
+
+            return result.ToString();
+        }
+
+        private static BigInteger ToNonNegativeBigInteger(byte[] bytes)
+        {
+            byte[] bytesWithTrailingZero = new byte[bytes.Length + 1];
+            Array.Copy(bytes, bytesWithTrailingZero, length: bytes.Length);
+            return new(bytesWithTrailingZero);
         }
     }
 }

--- a/source/DefaultDocumentation.Markdown/FileNameFactories/Md5Factory.cs
+++ b/source/DefaultDocumentation.Markdown/FileNameFactories/Md5Factory.cs
@@ -20,12 +20,8 @@ namespace DefaultDocumentation.Markdown.FileNameFactories
         public override string Name => ConfigName;
 
         /// <inheritdoc/>
-        protected override string GetMarkdownFileName(IGeneralContext context, DocItem item)
-        {
-            using MD5 md5 = MD5.Create();
-
-            return GetMd5HashBase36(item.FullName);
-        }
+        protected override string GetMarkdownFileName(IGeneralContext context, DocItem item) =>
+            GetMd5HashBase36(item.FullName);
 
         internal static string GetMd5HashBase36(string text)
         {

--- a/source/DefaultDocumentation.Markdown/FileNameFactories/NameAndMd5MixFactory.cs
+++ b/source/DefaultDocumentation.Markdown/FileNameFactories/NameAndMd5MixFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
+﻿using System.Linq;
 using DefaultDocumentation.Models;
 
 namespace DefaultDocumentation.Markdown.FileNameFactories

--- a/source/DefaultDocumentation.Markdown/FileNameFactories/NameAndMd5MixFactory.cs
+++ b/source/DefaultDocumentation.Markdown/FileNameFactories/NameAndMd5MixFactory.cs
@@ -22,10 +22,8 @@ namespace DefaultDocumentation.Markdown.FileNameFactories
         /// <inheritdoc/>
         protected override string GetMarkdownFileName(IGeneralContext context, DocItem item)
         {
-            using MD5 md5 = MD5.Create();
-
             return item is EntityDocItem entity && item is IParameterizedDocItem parameterized && parameterized.Parameters.Any()
-                ? $"{item.Parent!.GetLongName()}.{entity.Entity.Name}.{Convert.ToBase64String(md5.ComputeHash(Encoding.UTF8.GetBytes(item.FullName)))}"
+                ? $"{item.Parent!.GetLongName()}.{entity.Entity.Name}.{Md5Factory.GetMd5HashBase36(item.FullName)}"
                 : item.GetLongName();
         }
     }

--- a/source/DefaultDocumentation.Test/Markdown/FileNameFactories/Md5FactoryTest.cs
+++ b/source/DefaultDocumentation.Test/Markdown/FileNameFactories/Md5FactoryTest.cs
@@ -1,4 +1,5 @@
 ﻿using DefaultDocumentation.Markdown.FileNameFactories;
+using DefaultDocumentation.Models;
 using NFluent;
 using Xunit;
 
@@ -11,5 +12,25 @@ namespace DefaultDocumentation.Markdown.Markdown.FileNameFactories
 
         [Fact]
         public void GetFileName_Should_return_Md5() => Test(AssemblyInfo.ClassDocItem, "NFMDH6WUUDQ1ZFSD9PKB7FIB9.md");
+ 
+        [Fact]
+        public void GetFileName_Should_encode_as_nonnegative_BigInteger() =>
+            // Note: this name value was specifically chosen so that new BigInteger(MD5(UTF8Bytes(name))) < 0, therefore
+            // making our extra logic to ensure it is non-negative important.
+            GetAndValidateHash("ab");
+
+        [Fact]
+        public void GetFileName_Should_produce_shorter_hashes_for_leading_zeros() =>
+            // Note: this name value was specifically chosen so that the MD5 hash has multiple trailing zeros, yielding
+            // a small BigInteger value that requires fewer digits to encode
+            Check.That(GetAndValidateHash("W6D.IDDYuW")).IsEqualTo("9M5VBXDZBVZ0R9EMU25.md");
+
+        private string GetAndValidateHash(string fullName)
+        {
+            DocItem item = new NamespaceDocItem(AssemblyInfo.AssemblyDocItem, fullName, documentation: null);
+            string hash = new Md5Factory().GetFileName(_context.Value, item);
+            Check.That(hash).Matches(@"^[0-9A-Z]{1,25}\.md$");
+            return hash;
+        }
     }
 }

--- a/source/DefaultDocumentation.Test/Markdown/FileNameFactories/Md5FactoryTest.cs
+++ b/source/DefaultDocumentation.Test/Markdown/FileNameFactories/Md5FactoryTest.cs
@@ -12,7 +12,7 @@ namespace DefaultDocumentation.Markdown.Markdown.FileNameFactories
 
         [Fact]
         public void GetFileName_Should_return_Md5() => Test(AssemblyInfo.ClassDocItem, "NFMDH6WUUDQ1ZFSD9PKB7FIB9.md");
- 
+
         [Fact]
         public void GetFileName_Should_encode_as_nonnegative_BigInteger() =>
             // Note: this name value was specifically chosen so that new BigInteger(MD5(UTF8Bytes(name))) < 0, therefore

--- a/source/DefaultDocumentation.Test/Markdown/FileNameFactories/Md5FactoryTest.cs
+++ b/source/DefaultDocumentation.Test/Markdown/FileNameFactories/Md5FactoryTest.cs
@@ -10,6 +10,6 @@ namespace DefaultDocumentation.Markdown.Markdown.FileNameFactories
         public void Name_Should_return_FullName() => Check.That(Name).IsEqualTo("Md5");
 
         [Fact]
-        public void GetFileName_Should_return_Md5() => Test(AssemblyInfo.ClassDocItem, "07ucmh7NagP7qlcO1w9snQ.md");
+        public void GetFileName_Should_return_Md5() => Test(AssemblyInfo.ClassDocItem, "NFMDH6WUUDQ1ZFSD9PKB7FIB9.md");
     }
 }

--- a/source/DefaultDocumentation.Test/Markdown/FileNameFactories/NameAndMd5MixFactoryTest.cs
+++ b/source/DefaultDocumentation.Test/Markdown/FileNameFactories/NameAndMd5MixFactoryTest.cs
@@ -20,6 +20,6 @@ namespace DefaultDocumentation.Markdown.Markdown.FileNameFactories
         public void GetFileName_Should_return_LongName_When_no_parameter() => Test(AssemblyInfo.PropertyDocItem, $"{AssemblyInfo.PropertyDocItem.GetLongName()}.md");
 
         [Fact]
-        public void GetFileName_Should_return_LongName_and_Md5_When_parameters() => Test(AssemblyInfo.MethodWithParameterDocItem, "AssemblyInfo.MethodWithParameter.bcDxH9Sg4M1dGXINePLLPg.md");
+        public void GetFileName_Should_return_LongName_and_Md5_When_parameters() => Test(AssemblyInfo.MethodWithParameterDocItem, "AssemblyInfo.MethodWithParameter.5EBN351WOG79CZJJQ2Y6P5UP3.md");
     }
 }


### PR DESCRIPTION
fix #119