### PR TITLE
Use literal Unicode arrows instead of HTML numeric entities

### DIFF
--- a/source/DefaultDocumentation.Markdown/Sections/DerivedSection.cs
+++ b/source/DefaultDocumentation.Markdown/Sections/DerivedSection.cs
@@ -37,7 +37,7 @@ public sealed class DerivedSection : ISection
                 {
                     writer
                         .AppendLine("  ")
-                        .Append("&#8627; ")
+                        .Append("↳ ")
                         .AppendLink(t);
                 }
             }

--- a/source/DefaultDocumentation.Markdown/Sections/InheritanceSection.cs
+++ b/source/DefaultDocumentation.Markdown/Sections/InheritanceSection.cs
@@ -34,7 +34,7 @@ public sealed class InheritanceSection : ISection
             {
                 writer
                     .AppendLink(typeItem, t)
-                    .Append(" &#129106; ");
+                    .Append(" → ");
             }
 
             writer.Append(typeItem.Name.SanitizeForMarkdown(writer.Context.GetMarkdownSanitizationRegex()));

--- a/source/DefaultDocumentation.Test/Markdown/Sections/DerivedSectionTests/WriteShould.cs
+++ b/source/DefaultDocumentation.Test/Markdown/Sections/DerivedSectionTests/WriteShould.cs
@@ -20,8 +20,8 @@ public sealed class WriteShould : BaseSectionTester<DerivedSection>
     public void Write() => Test(
         AssemblyInfo.InterfaceDocItem,
 @"Derived  
-&#8627; [AssemblyInfo](T:DefaultDocumentation.AssemblyInfo 'DefaultDocumentation\.AssemblyInfo')  
-&#8627; [Struct](T:DefaultDocumentation.AssemblyInfo.Struct 'DefaultDocumentation\.AssemblyInfo\.Struct')");
+↳ [AssemblyInfo](T:DefaultDocumentation.AssemblyInfo 'DefaultDocumentation\.AssemblyInfo')  
+↳ [Struct](T:DefaultDocumentation.AssemblyInfo.Struct 'DefaultDocumentation\.AssemblyInfo\.Struct')");
 
     [Fact]
     public void WriteNewlineWhenNeeded() => Test(
@@ -30,6 +30,6 @@ public sealed class WriteShould : BaseSectionTester<DerivedSection>
 @"pouet
 
 Derived  
-&#8627; [AssemblyInfo](T:DefaultDocumentation.AssemblyInfo 'DefaultDocumentation\.AssemblyInfo')  
-&#8627; [Struct](T:DefaultDocumentation.AssemblyInfo.Struct 'DefaultDocumentation\.AssemblyInfo\.Struct')");
+↳ [AssemblyInfo](T:DefaultDocumentation.AssemblyInfo 'DefaultDocumentation\.AssemblyInfo')  
+↳ [Struct](T:DefaultDocumentation.AssemblyInfo.Struct 'DefaultDocumentation\.AssemblyInfo\.Struct')");
 }

--- a/source/DefaultDocumentation.Test/Markdown/Sections/InheritanceSectionTests/WriteShould.cs
+++ b/source/DefaultDocumentation.Test/Markdown/Sections/InheritanceSectionTests/WriteShould.cs
@@ -15,7 +15,7 @@ public sealed class WriteShould : BaseSectionTester<InheritanceSection>
     [Fact]
     public void Write() => Test(
         AssemblyInfo.ClassDocItem,
-        @"Inheritance [System\.Object](T:System.Object 'System\.Object') &#129106; AssemblyInfo");
+        @"Inheritance [System\.Object](T:System.Object 'System\.Object') → AssemblyInfo");
 
     [Fact]
     public void WriteNewlineWhenNeeded() => Test(
@@ -23,5 +23,5 @@ public sealed class WriteShould : BaseSectionTester<InheritanceSection>
         w => w.Append("pouet"),
 @"pouet
 
-Inheritance [System\.Object](T:System.Object 'System\.Object') &#129106; AssemblyInfo");
+Inheritance [System\.Object](T:System.Object 'System\.Object') → AssemblyInfo");
 }


### PR DESCRIPTION
## Summary

The `Inheritance` and `Derived` section writers emit `&#129106;` (U+1F852) and `&#8627;` (U+21B3) as raw HTML numeric entities in their markdown output. When the generated markdown is consumed as plain text — by LLMs, raw-markdown viewers, or anything that doesn't decode HTML entities — those entities show up literally as `&#129106;` instead of the intended arrow.

This PR replaces them with the equivalent Unicode characters directly:

- `InheritanceSection`: `&#129106;` → `→` (U+2192, RIGHTWARDS ARROW)
- `DerivedSection`: `&#8627;` → `↳` (U+21B3, DOWNWARDS ARROW WITH TIP RIGHTWARDS)

I swapped U+1F852 for U+2192 in `InheritanceSection` because U+2192 lives in the standard Arrows block and is universally supported by fonts, whereas U+1F852 (Supplemental Arrows-C) often falls back to tofu. U+21B3 was kept as-is — it's already in the standard Arrows block.

HTML rendering is unaffected: HTML viewers render these literal characters identically to the original entities.

## Test plan

- [x] Updated fixtures in `InheritanceSectionTests/WriteShould.cs` and `DerivedSectionTests/WriteShould.cs`
- [x] `dotnet test --filter "FullyQualifiedName~InheritanceSectionTests|FullyQualifiedName~DerivedSectionTests"` → 9/9 passing